### PR TITLE
[#3] - Babelify the output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-dist/*.js
+dist/**/*
 examples/dist/*.js
 coverage
 

--- a/examples/webpack.config.live.babel.js
+++ b/examples/webpack.config.live.babel.js
@@ -58,12 +58,16 @@ export default () => ({
       {
         test: /\.(scss)$/,
         loader: 'style-loader!css-loader!sass-loader'
+      },
+      {
+        test: /\.(css)$/,
+        loader: 'style-loader!css-loader'
       }
     ]
   },
 
   resolve: {
-    extensions: ['.js', '.jsx', '.scss']
+    extensions: ['.js', '.jsx', '.scss', '.css']
   },
 
   plugins: [new webpack.HotModuleReplacementPlugin()],

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+  coverageReporters: [
+    'json',
+    'lcov',
+    'text-summary'
+  ],
+  moduleFileExtensions: [
+    'js',
+    'jsx',
+    'scss'
+  ],
+  modulePaths: [
+    './src'
+  ],
+  setupFiles: [
+    '<rootDir>/config/jest/setup.js'
+  ],
+  transform: {
+    '^.+\\.(js|jsx)$': '<rootDir>/node_modules/babel-jest',
+    '^.+\\.css$': '<rootDir>/config/jest/cssTransform.js',
+    '^(?!.*\\.(js|jsx|css|json)$)': '<rootDir>/config/jest/fileTransform.js'
+  },
+  transformIgnorePatterns: [
+    '[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,32 +13,6 @@
     "start": "webpack-dev-server --config examples/webpack.config.live.babel.js",
     "test": "npm run lint && npm run coverage"
   },
-  "jest": {
-    "coverageReporters": [
-      "json",
-      "lcov",
-      "text-summary"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "jsx",
-      "scss"
-    ],
-    "modulePaths": [
-      "./src"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/jest/setup.js"
-    ],
-    "transform": {
-      "^.+\\.(js|jsx)$": "<rootDir>/node_modules/babel-jest",
-      "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
-      "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
-    },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ]
-  },
   "dependencies": {
     "react": "^16.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Boilerplate to quickstart React component development",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "webpack --config webpack.config.babel.js",
+    "build-scss": "node-sass src -o dist",
+    "build": "npm run clean && npm run build-scss && babel src --out-dir dist",
     "build-examples": "webpack --config examples/webpack.config.babel.js --progress",
     "clean": "rm -rf dist coverage",
     "coverage": "jest --coverage",
@@ -17,6 +18,7 @@
     "react": "^16.6.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.1.5",
     "@babel/core": "^7.1.2",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
@@ -35,7 +37,6 @@
     "node-sass": "^4.7.2",
     "prop-types": "^15.6.0",
     "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^16.6.0",
     "react-hot-loader": "next",
     "react-test-renderer": "^16.0.0",
     "regenerator-runtime": "^0.12.1",
@@ -44,6 +45,10 @@
     "webpack": "^4.9.1",
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.4"
+  },
+  "peerDependencies": {
+    "react": ">= 16.3.0",
+    "react-dom": ">= 16.3.0"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"


### PR DESCRIPTION
Issue: #3 

@flexdinesh We mustn't build react along with the library as it has performance concerns. So instead we just transpile the source code using babel and put only the transpiled code in the package. This not only reduces the overall size of the package but also saves significant time for the user of the library in saving memory and time involved with loading two react code bases. You can do a manual testing by compiling the package locally and installing it in another repository and use it.

And hey merge #2 before merging this one. 😄 